### PR TITLE
Add model-based tests

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,9 @@ if [ ! -f package.json ]; then
   "type": "module",
   "dependencies": {
     "three": "^0.177.0"
+  },
+  "devDependencies": {
+    "linkedom": "^0.16.0"
   }
 }
 JSON

--- a/test/dotMaterialLoader.test.js
+++ b/test/dotMaterialLoader.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mod as ogre } from './loadOgreMax.js';
+const { DotMaterialLoader, DotMaterialError } = ogre;
+
+// invalid material text used to test error handling
+const invalidText = `material Bad { technique { pass { diffuse 1 0 0 } }`;
+
+test('DotMaterialLoader.texturePath setter validates input', () => {
+  const loader = new DotMaterialLoader();
+  loader.texturePath = 'textures/';
+  assert.equal(loader.texturePath, 'textures/');
+  assert.throws(() => { loader.texturePath = 123; }, DotMaterialError);
+});
+
+test('DotMaterialLoader.parse throws on malformed input', () => {
+  const loader = new DotMaterialLoader();
+  assert.throws(() => loader.parse(invalidText), DotMaterialError);
+});

--- a/test/loadOgreMax.js
+++ b/test/loadOgreMax.js
@@ -1,0 +1,13 @@
+import fs from 'fs';
+import { pathToFileURL } from 'url';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const source = fs.readFileSync(new URL('../OgreMaxLoader.js', import.meta.url), 'utf8')
+  .replace("import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';", "import * as THREE from 'three';");
+
+const tmpDir = dirname(fileURLToPath(import.meta.url));
+const tmpFile = join(tmpDir, `tmp_OgreMaxLoader_${process.pid}_${Math.random().toString(36).slice(2)}.mjs`);
+fs.writeFileSync(tmpFile, source);
+export const mod = await import(pathToFileURL(tmpFile));
+fs.unlinkSync(tmpFile);

--- a/test/modelLoad.test.js
+++ b/test/modelLoad.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mod as ogre } from './loadOgreMax.js';
+const { OgreMaxLoader } = ogre;
+import { DOMParser } from 'linkedom';
+import * as THREE from 'three';
+import { fileURLToPath } from 'url';
+import fs from 'fs';
+import { dirname, join } from 'path';
+
+// polyfill DOMParser for OgreMaxLoader.load()
+global.DOMParser = DOMParser;
+
+// stub texture loader to avoid image dependencies
+THREE.TextureLoader.prototype.load = function(url, onLoad) {
+  const tex = new THREE.Texture();
+  if (onLoad) onLoad(tex);
+  return tex;
+};
+
+const root = dirname(fileURLToPath(import.meta.url));
+const skeletonPath = join(root, '../exemple/res/models/PlayerMdl.skeleton.xml');
+
+test('OgreMaxLoader parses skeleton file', () => {
+  const loader = new OgreMaxLoader();
+  const skelXML = new DOMParser().parseFromString(fs.readFileSync(skeletonPath, 'utf8'), 'text/xml');
+  const skel = loader.parse(skelXML).skeleton;
+  assert.ok(skel.skeleton.bones.length > 0);
+});
+

--- a/test/ogreMaxLoader.test.js
+++ b/test/ogreMaxLoader.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mod as ogre } from './loadOgreMax.js';
+const { OgreMaxLoader } = ogre;
+import { DOMParser } from 'linkedom';
+
+// minimal mesh without geometry
+const emptyMesh = `<mesh></mesh>`;
+
+test('OgreMaxLoader.parse throws for mesh without geometry', () => {
+  const loader = new OgreMaxLoader();
+  const xml = new DOMParser().parseFromString(emptyMesh, 'text/xml');
+  assert.throws(() => loader.parse(xml), /Mesh contains no geometry/);
+});
+
+// unknown root node
+const unknownXml = `<foo></foo>`;
+
+test('OgreMaxLoader.parse throws for unknown root node', () => {
+  const loader = new OgreMaxLoader();
+  const xml = new DOMParser().parseFromString(unknownXml, 'text/xml');
+  assert.throws(() => loader.parse(xml), /Unknown root node/);
+});


### PR DESCRIPTION
## Summary
- include linkedom as a dev dependency in `install.sh`
- load OgreMaxLoader in tests using a unique temporary file
- test parsing of the provided skeleton model

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_684aa247408083268c46d4a040ee163a