### PR TITLE
Add loader test and fix parser

### DIFF
--- a/OgreMaxLoader.js
+++ b/OgreMaxLoader.js
@@ -59,7 +59,8 @@
  */
 'use strict';
 
-import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+// Use local three module in Node.js test environment
+import * as THREE from 'three';
 THREE.Cache.enabled = true;
 
 /**
@@ -360,9 +361,9 @@ class OgreMaxLoader extends THREE.Loader {
 			}
 
 			// faces → indices
-			if (facesNode) {
-				this.#parseFaces(facesNode, indices, base, base);
-			}
+                        if (facesNode) {
+                                this.#parseFaces(facesNode, indices, base, positions.length / 3);
+                        }
 
 			// bone assignments
 			if (boneNode) {
@@ -1741,8 +1742,9 @@ class DotMaterialLoader extends THREE.Loader {
 						m.transparent = true;
 						m.blending = tokens[1] === 'add' ? THREE.AdditiveBlending : THREE.NormalBlending;
 						break;
-					case 'texture_unit':
-						handleTextureUnit();
+                                case 'texture_unit':
+                                                i--; // let handleTextureUnit consume the line
+                                                handleTextureUnit();
 						break;
 					default:
 						/* ignore */

--- a/test/modelLoad.test.js
+++ b/test/modelLoad.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from 'three';
+import { OgreMaxLoader } from '../OgreMaxLoader.js';
+import { JSDOM } from 'jsdom';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+global.DOMParser = new JSDOM('').window.DOMParser;
+
+function stubLoaders() {
+  THREE.FileLoader.prototype.load = function(url, onLoad, onProgress, onError) {
+    if (this.path !== undefined) url = this.path + url;
+    url = this.manager.resolveURL(url);
+    const fullPath = path.resolve(url);
+    this.manager.itemStart(url);
+    try {
+      const data = fs.readFileSync(fullPath);
+      const result = this.responseType === 'arraybuffer'
+        ? data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength)
+        : data.toString();
+      if (onLoad) onLoad(result);
+      this.manager.itemEnd(url);
+    } catch (err) {
+      this.manager.itemError(url);
+      if (onError) onError(err);
+    }
+  };
+
+  THREE.TextureLoader.prototype.load = function(url, onLoad) {
+    const tex = new THREE.Texture();
+    if (onLoad) onLoad(tex);
+    return tex;
+  };
+}
+
+stubLoaders();
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const modelBase = path.resolve(__dirname, '../exemple/res/models');
+
+test('OgreMaxLoader loads PlayerMdl.scene', async () => {
+  const loader = new OgreMaxLoader();
+  const scene = await loader.load(path.join(modelBase, 'PlayerMdl.scene'));
+  assert.ok(scene instanceof THREE.Scene, 'returns a THREE.Scene');
+
+  const node = scene.getObjectByName('PlayerMdl');
+  assert.ok(node, 'PlayerMdl node present');
+  const mesh = node.children[0];
+  assert.ok(mesh instanceof THREE.SkinnedMesh, 'contains skinned mesh');
+
+  assert.ok(mesh.material, 'material resolved');
+  assert.ok(mesh.skeleton instanceof THREE.Skeleton, 'skeleton resolved');
+  assert.ok(mesh.skeleton.bones.length > 0, 'skeleton has bones');
+});


### PR DESCRIPTION
## Summary
- use local three module for Node testing
- fix face range check and texture unit parsing
- add a model loading test that verifies materials and skeletons

## Testing
- `node --test test/modelLoad.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684aac4384ac8326ad7d78bd8089359c